### PR TITLE
tile_only option

### DIFF
--- a/pt3/client.py
+++ b/pt3/client.py
@@ -230,6 +230,12 @@ def should_ignore(client):
             if set([inst.lower(), cls.lower()]).intersection(config.ignore):
                 debug('Ignoring %s because it is in the ignore list' % nm)
                 return True
+
+            if hasattr(config, 'tile_only') and config.tile_only:
+              if not set([inst.lower(), cls.lower()]).intersection(config.tile_only):
+                debug('Ignoring %s because it is not in the tile_only list' % nm)
+                return True
+
         except ValueError:
             pass
 


### PR DESCRIPTION
Hey!

I've implemented a small change to pytyle 3. Users now can specify a list of window classes that should be tiled, ignoring all other windows not in this list.

I use this to make pytyle3 only tile my urxvt terminals. Adding everything else to the ignore list would've been too much work ;)

regards,
Fabian
