### PR TITLE
Bug fix.

### DIFF
--- a/pt3/layouts/layout_vert_horz.py
+++ b/pt3/layouts/layout_vert_horz.py
@@ -113,6 +113,10 @@ class OrientLayout(Layout):
     # Begin private methods that should not be called by the user directly
 
     def _get_focused(self):
+        
+        if type(state.activewin) == list:
+            state.activewin = state.activewin[0]
+        
         if state.activewin not in client.clients:
             return None
 


### PR DESCRIPTION
Fixed: "if state.activewin not in client.clients" error which occurred when Mod+j or Mod+k were pressed.
